### PR TITLE
Add karaoke transcript page with word highlighting

### DIFF
--- a/web/static/css/karaoke.css
+++ b/web/static/css/karaoke.css
@@ -1,0 +1,7 @@
+#transcript span {
+  cursor: pointer;
+}
+
+.highlight {
+  background-color: yellow;
+}

--- a/web/static/js/karaoke.js
+++ b/web/static/js/karaoke.js
@@ -1,0 +1,41 @@
+// Load words and build transcript
+window.addEventListener('DOMContentLoaded', () => {
+  const audio = document.getElementById('audio');
+  const container = document.getElementById('transcript');
+  let words = [];
+  let segmentEnd = null;
+
+  fetch('/static/words.json')
+    .then((resp) => resp.json())
+    .then((data) => {
+      words = data;
+      words.forEach((w) => {
+        const span = document.createElement('span');
+        span.textContent = w.word + ' ';
+        span.dataset.start = w.start;
+        span.dataset.end = w.end;
+        span.addEventListener('click', () => {
+          segmentEnd = w.end;
+          audio.currentTime = w.start;
+          audio.play();
+        });
+        container.appendChild(span);
+      });
+    });
+
+  audio.addEventListener('timeupdate', () => {
+    const t = audio.currentTime;
+    if (segmentEnd !== null && t >= segmentEnd) {
+      audio.pause();
+      segmentEnd = null;
+    }
+    words.forEach((w, i) => {
+      const span = container.children[i];
+      if (t >= w.start && t < w.end) {
+        span.classList.add('highlight');
+      } else {
+        span.classList.remove('highlight');
+      }
+    });
+  });
+});

--- a/web/templates/transcript.html
+++ b/web/templates/transcript.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Transcript</title>
+    <link rel="stylesheet" href="/static/css/karaoke.css">
+</head>
+<body>
+    <audio id="audio" controls></audio>
+    <div id="transcript"></div>
+    <script src="/static/js/karaoke.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Create transcript page with audio player and transcript container
- Implement karaoke-style highlighting and word click playback
- Add CSS styles for highlighted words

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a608d61190832e80db405895adb5d3