### PR TITLE
feat: add build pages script

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,8 +320,9 @@ If you use this in your research, please cite the paper:
 
 1. Coloca tus archivos de audio en `data/audio/`.
 2. Ejecuta los scripts de `scripts/` para procesar el audio y generar transcripciones.
-3. Las transcripciones resultantes se guardan en `data/transcripts/`.
-4. La interfaz web utiliza los archivos dentro de `web/`.
+3. Genera las páginas HTML ejecutando `python scripts/build_pages.py`.
+4. Las transcripciones resultantes se guardan en `data/transcripts/`.
+5. La interfaz web utiliza los archivos dentro de `web/`.
 
 ## Estructura de carpetas
 

--- a/scripts/build_pages.py
+++ b/scripts/build_pages.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import json
+import os
+import shutil
+from pathlib import Path
+
+TEMPLATE_PATH = Path("web/templates/transcript.html")
+TRANSCRIPTS_DIR = Path("data/transcripts")
+AUDIO_DIR = Path("data/audio")
+PAGES_DIR = Path("web/pages")
+
+
+def build_pages() -> None:
+    """Generate an HTML page for each transcript JSON."""
+    if not TEMPLATE_PATH.exists():
+        raise FileNotFoundError(f"Template not found: {TEMPLATE_PATH}")
+
+    template = TEMPLATE_PATH.read_text(encoding="utf-8")
+    PAGES_DIR.mkdir(parents=True, exist_ok=True)
+
+    for json_file in TRANSCRIPTS_DIR.glob("*.json"):
+        data = json.loads(json_file.read_text(encoding="utf-8"))
+        title = data.get("title", json_file.stem)
+
+        audio_file = next(AUDIO_DIR.glob(f"{json_file.stem}.*"), None)
+        if audio_file is None:
+            print(f"Skipping {json_file.name}: audio file not found")
+            continue
+
+        dest_audio = PAGES_DIR / audio_file.name
+        shutil.copy(audio_file, dest_audio)
+
+        audio_src = dest_audio.name
+        json_src = os.path.relpath(json_file, PAGES_DIR)
+
+        html = template.format(title=title, audio_src=audio_src, json_src=json_src)
+        (PAGES_DIR / f"{json_file.stem}.html").write_text(html, encoding="utf-8")
+
+
+if __name__ == "__main__":
+    build_pages()

--- a/web/templates/transcript.html
+++ b/web/templates/transcript.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>{title}</title>
+</head>
+<body>
+  <h1>{title}</h1>
+  <audio controls src="{audio_src}"></audio>
+  <script src="{json_src}" type="application/json"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add template-based script to generate transcript pages
- document new workflow step for building web pages

## Testing
- `python scripts/build_pages.py`
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a60d15ebe8832e8d28b3b3a16d1190