### PR TITLE
Add script for generating transcript web pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,7 +320,9 @@ If you use this in your research, please cite the paper:
 
 1. Coloca tus archivos de audio en `data/audio/`.
 2. Ejecuta los scripts de `scripts/` para procesar el audio y generar transcripciones.
-3. Genera las páginas HTML ejecutando `python scripts/build_pages.py`.
+3. Genera las páginas HTML con `python scripts/build_pages.py`. Este comando copia cada
+   archivo de audio a `web/pages/` y crea un HTML que referencia al audio y al JSON de la
+   transcripción.
 4. Las transcripciones resultantes se guardan en `data/transcripts/`.
 5. La interfaz web utiliza los archivos dentro de `web/`.
 

--- a/scripts/build_pages.py
+++ b/scripts/build_pages.py
@@ -32,10 +32,12 @@ def build_pages() -> None:
         shutil.copy(audio_file, dest_audio)
 
         audio_src = dest_audio.name
-        json_src = os.path.relpath(json_file, PAGES_DIR)
+        json_src = os.path.relpath(json_file, PAGES_DIR).replace(os.sep, "/")
 
         html = template.format(title=title, audio_src=audio_src, json_src=json_src)
-        (PAGES_DIR / f"{json_file.stem}.html").write_text(html, encoding="utf-8")
+        dest_html = PAGES_DIR / f"{json_file.stem}.html"
+        dest_html.write_text(html, encoding="utf-8")
+        print(f"Wrote {dest_html}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- ensure `build_pages.py` copies audio, links JSON, and reports generated files
- document how to build HTML transcript pages

## Testing
- `pytest`
- `python scripts/build_pages.py`

------
https://chatgpt.com/codex/tasks/task_e_68a61aa398dc832e925eae9151354772