### PR TITLE
Add transcript page for audio.wav

### DIFF
--- a/web/static/js/karaoke.js
+++ b/web/static/js/karaoke.js
@@ -5,7 +5,9 @@ window.addEventListener('DOMContentLoaded', () => {
   let words = [];
   let segmentEnd = null;
 
-  fetch('/static/words.json')
+  const jsonSrc = container.dataset.json || '/static/words.json';
+
+  fetch(jsonSrc)
     .then((resp) => resp.json())
     .then((data) => {
       words = data;

--- a/web/templates/transcript.html
+++ b/web/templates/transcript.html
@@ -1,20 +1,14 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="es">
 <head>
-  <meta charset="UTF-8" />
-  <title>{title}</title>
+  <meta charset="UTF-8">
+  <title>Transcripción de audio</title>
+  <link rel="stylesheet" href="/static/css/karaoke.css">
 </head>
 <body>
-  <h1>{title}</h1>
-  <audio controls src="{audio_src}"></audio>
-  <script src="{json_src}" type="application/json"></script>
-    <meta charset="UTF-8">
-    <title>Transcript</title>
-    <link rel="stylesheet" href="/static/css/karaoke.css">
-</head>
-<body>
-    <audio id="audio" controls></audio>
-    <div id="transcript"></div>
-    <script src="/static/js/karaoke.js"></script>
+  <h1>Transcripción de audio.wav</h1>
+  <audio id="audio" controls src="/data/audio/audio.wav"></audio>
+  <div id="transcript" data-json="/data/transcripts/audio.json"></div>
+  <script src="/static/js/karaoke.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add transcript template for audio.wav with audio player and word-level highlighting
- make karaoke.js load word timings from configurable JSON source
- remove back button from transcript page

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a69e9c27f8832e98c2fb5d29bcf3a4