### PR TITLE
Add HTML page for audio transcription

### DIFF
--- a/web/pages/audio.html
+++ b/web/pages/audio.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <title>Transcripción de audio</title>
+  <link rel="stylesheet" href="/static/css/karaoke.css">
+</head>
+<body>
+  <h1>Transcripción de audio.wav</h1>
+  <audio id="audio" controls src="/data/audio/audio.wav"></audio>
+  <div id="transcript" data-json="/data/transcripts/audio.json"></div>
+  <script src="/static/js/karaoke.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add generated HTML page that plays `audio.wav` and displays its transcript using existing karaoke script.

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a6a6baa4a4832ea2953537b5369d7b